### PR TITLE
Add missing Micronaut BOMs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ managed-micronaut-kubernetes = "3.5.0-SNAPSHOT"
 managed-micronaut-micrometer = "5.0.0-SNAPSHOT"
 managed-micronaut-microstream = "2.0.0-SNAPSHOT"
 managed-micronaut-liquibase = "6.0.0-SNAPSHOT"
+managed-micronaut-logging = "1.0.0-SNAPSHOT"
 managed-micronaut-mongo = "5.0.0-M1"
 managed-micronaut-mqtt = "3.0.0-SNAPSHOT"
 managed-micronaut-multitenancy = "5.0.0-M1"
@@ -55,6 +56,7 @@ managed-micronaut-openapi = "5.0.0-SNAPSHOT"
 managed-micronaut-oraclecloud = "3.0.0-SNAPSHOT"
 managed-micronaut-picocli = "5.0.0-M1"
 managed-micronaut-problem = "3.0.0-SNAPSHOT"
+managed-micronaut-pulsar = "2.0.0-SNAPSHOT"
 managed-micronaut-rabbitmq = "4.0.0-SNAPSHOT"
 managed-micronaut-r2dbc = "5.0.0-SNAPSHOT"
 managed-micronaut-reactor = "3.0.0-M1"
@@ -101,43 +103,51 @@ parent-maven-enforcer-plugin = "3.2.1"
 
 [libraries]
 # Libraries prefixed with bom- are BOM files
+boms-micronaut-acme = { module = "io.micronaut.acme:micronaut-acme-bom", version.ref = "managed-micronaut-acme" }
 boms-micronaut-aws = { module = "io.micronaut.aws:micronaut-aws-bom", version.ref = "managed-micronaut-aws" }
 boms-micronaut-azure = { module = "io.micronaut.azure:micronaut-azure-bom", version.ref = "managed-micronaut-azure" }
 boms-micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "managed-micronaut-cache" }
 boms-micronaut-cassandra = { module = "io.micronaut.cassandra:micronaut-cassandra-bom", version.ref = "managed-micronaut-cassandra" }
-boms-micronaut-core = { module = "io.micronaut:micronaut-core-bom", version.ref = "managed-micronaut-core" }
 boms-micronaut-coherence = { module = "io.micronaut.coherence:micronaut-coherence-bom", version.ref = "managed-micronaut-coherence" }
+boms-micronaut-core = { module = "io.micronaut:micronaut-core-bom", version.ref = "managed-micronaut-core" }
 boms-micronaut-crac = { module = "io.micronaut.crac:micronaut-crac-bom", version.ref = "managed-micronaut-crac" }
-boms-micronaut-email = { module = "io.micronaut.email:micronaut-email-bom", version.ref = "managed-micronaut-email" }
 boms-micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "managed-micronaut-data" }
+boms-micronaut-discovery = { module = "io.micronaut.discovery:micronaut-discovery-client-bom", version.ref = "managed-micronaut-discovery" }
 boms-micronaut-elasticsearch = { module = "io.micronaut.elasticsearch:micronaut-elasticsearch-bom", version.ref = "managed-micronaut-elasticsearch" }
+boms-micronaut-email = { module = "io.micronaut.email:micronaut-email-bom", version.ref = "managed-micronaut-email" }
+boms-micronaut-flyway = { module = "io.micronaut.flyway:micronaut-flyway-bom", version.ref = "managed-micronaut-flyway" }
 boms-micronaut-gcp = { module = "io.micronaut.gcp:micronaut-gcp-bom", version.ref = "managed-micronaut-gcp" }
 boms-micronaut-graphql = { module = "io.micronaut.graphql:micronaut-graphql-bom", version.ref = "managed-micronaut-graphql" }
-boms-micronaut-grpc = { module = "io.micronaut.grpc:micronaut-grpc-bom", version.ref = "managed-micronaut-grpc" }
 boms-micronaut-groovy = { module = "io.micronaut.groovy:micronaut-groovy-bom", version.ref = "managed-micronaut-groovy" }
+boms-micronaut-grpc = { module = "io.micronaut.grpc:micronaut-grpc-bom", version.ref = "managed-micronaut-grpc" }
 boms-micronaut-hibernate-validator = { module = "io.micronaut.beanvalidation:micronaut-hibernate-validator-bom", version.ref = "managed-micronaut-hibernate-validator" }
 boms-micronaut-jaxrs = { module = "io.micronaut.jaxrs:micronaut-jaxrs-bom", version.ref = "managed-micronaut-jaxrs" }
+boms-micronaut-jmx = { module = "io.micronaut.jmx:micronaut-jmx-bom", version.ref = "managed-micronaut-jmx" }
 boms-micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "managed-micronaut-kafka" }
 boms-micronaut-kotlin = { module = "io.micronaut.kotlin:micronaut-kotlin-bom", version.ref = "managed-micronaut-kotlin" }
 boms-micronaut-kubernetes = { module = "io.micronaut.kubernetes:micronaut-kubernetes-bom", version.ref = "managed-micronaut-kubernetes" }
 boms-micronaut-liquibase = { module = "io.micronaut.liquibase:micronaut-liquibase-bom", version.ref = "managed-micronaut-liquibase" }
+boms-micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "managed-micronaut-logging" }
 boms-micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "managed-micronaut-micrometer" }
 boms-micronaut-microstream = { module = "io.micronaut.microstream:micronaut-microstream-bom", version.ref = "managed-micronaut-microstream" }
 boms-micronaut-mongo = { module = "io.micronaut.mongodb:micronaut-mongo-bom", version.ref = "managed-micronaut-mongo" }
-boms-micronaut-multitenancy = { module = "io.micronaut.multitenancy:micronaut-multitenancy-bom", version.ref = "managed-micronaut-multitenancy" }
 boms-micronaut-mqtt = { module = "io.micronaut.mqtt:micronaut-mqtt-bom", version.ref = "managed-micronaut-mqtt" }
+boms-micronaut-multitenancy = { module = "io.micronaut.multitenancy:micronaut-multitenancy-bom", version.ref = "managed-micronaut-multitenancy" }
 boms-micronaut-nats = { module = "io.micronaut.nats:micronaut-nats-bom", version.ref = "managed-micronaut-nats" }
 boms-micronaut-neo4j = { module = "io.micronaut.neo4j:micronaut-neo4j-bom", version.ref = "managed-micronaut-neo4j" }
 boms-micronaut-object-storage = { module = "io.micronaut.objectstorage:micronaut-object-storage-bom", version.ref = "managed-micronaut-object-storage" }
-boms-micronaut-oraclecloud = { module = "io.micronaut.oraclecloud:micronaut-oraclecloud-bom", version.ref = "managed-micronaut-oraclecloud" }
 boms-micronaut-openapi = { module = "io.micronaut.openapi:micronaut-openapi-bom", version.ref = "managed-micronaut-openapi" }
+boms-micronaut-oraclecloud = { module = "io.micronaut.oraclecloud:micronaut-oraclecloud-bom", version.ref = "managed-micronaut-oraclecloud" }
 boms-micronaut-picocli = { module = "io.micronaut.picocli:micronaut-picocli-bom", version.ref = "managed-micronaut-picocli" }
 boms-micronaut-problem-json = { module = "io.micronaut.problem:micronaut-problem-json-bom", version.ref = "managed-micronaut-problem" }
+boms-micronaut-pulsar = { module = "io.micronaut.pulsar:micronaut-pulsar-bom", version.ref = "managed-micronaut-pulsar" }
+boms-micronaut-r2dbc = { module = "io.micronaut.r2dbc:micronaut-r2dbc-bom", version.ref = "managed-micronaut-r2dbc" }
+boms-micronaut-rabbitmq = { module = "io.micronaut.rabbitmq:micronaut-rabbitmq-bom", version.ref = "managed-micronaut-rabbitmq" }
+boms-micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", version.ref = "managed-micronaut-reactor" }
 boms-micronaut-redis = { module = "io.micronaut.redis:micronaut-redis-bom", version.ref = "managed-micronaut-redis" }
 boms-micronaut-rss = { module = "io.micronaut.rss:micronaut-rss-bom", version.ref = "managed-micronaut-rss" }
 boms-micronaut-rxjava2 = { module = "io.micronaut.rxjava2:micronaut-rxjava2-bom", version.ref = "managed-micronaut-rxjava2" }
 boms-micronaut-rxjava3 = { module = "io.micronaut.rxjava3:micronaut-rxjava3-bom", version.ref = "managed-micronaut-rxjava3" }
-boms-micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", version.ref = "managed-micronaut-reactor" }
 boms-micronaut-security = { module = "io.micronaut.security:micronaut-security-bom", version.ref = "managed-micronaut-security" }
 boms-micronaut-serialization = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "managed-micronaut-serialization" }
 boms-micronaut-servlet = { module = "io.micronaut.servlet:micronaut-servlet-bom", version.ref = "managed-micronaut-servlet" }
@@ -145,13 +155,11 @@ boms-micronaut-session = { module = "io.micronaut.session:micronaut-session-bom"
 boms-micronaut-spring = { module = "io.micronaut.spring:micronaut-spring-bom", version.ref = "managed-micronaut-spring" }
 boms-micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "managed-micronaut-sql" }
 boms-micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "managed-micronaut-test" }
+boms-micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "managed-micronaut-test-resources" }
 boms-micronaut-toml = { module = "io.micronaut.toml:micronaut-toml-bom", version.ref = "managed-micronaut-toml" }
 boms-micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "managed-micronaut-tracing" }
 boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "managed-micronaut-validation" }
 boms-micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", version.ref = "managed-micronaut-views" }
-boms-micronaut-r2dbc = { module = "io.micronaut.r2dbc:micronaut-r2dbc-bom", version.ref = "managed-micronaut-r2dbc" }
-boms-micronaut-flyway = { module = "io.micronaut.flyway:micronaut-flyway-bom", version.ref = "managed-micronaut-flyway" }
-boms-micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "managed-micronaut-test-resources" }
 
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
 boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
@@ -181,16 +189,11 @@ managed-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "ma
 managed-lombok = { module = "org.projectlombok:lombok", version.ref = "managed-lombok" }
 
 # The following Managed Micronaut dependencies are for Micronaut projects which do not ship with a BOM yet
-managed-micronaut-acme = { module = "io.micronaut.acme:micronaut-acme", version.ref = "managed-micronaut-acme" }
-managed-micronaut-discovery = { module = "io.micronaut.discovery:micronaut-discovery-client", version.ref = "managed-micronaut-discovery" }
 managed-micronaut-jms = { module = "io.micronaut.jms:micronaut-jms-core", version.ref = "managed-micronaut-jms" }
 managed-micronaut-jms-activemq-classic = { module = "io.micronaut.jms:micronaut-jms-activemq-classic", version.ref = "managed-micronaut-jms" }
 managed-micronaut-jms-activemq-artemis = { module = "io.micronaut.jms:micronaut-jms-activemq-artemis", version.ref = "managed-micronaut-jms" }
 managed-micronaut-jms-sqs = { module = "io.micronaut.jms:micronaut-jms-sqs", version.ref = "managed-micronaut-jms" }
-managed-micronaut-jmx = { module = "io.micronaut.jmx:micronaut-jmx", version.ref = "managed-micronaut-jmx" }
-managed-micronaut-rabbitmq = { module = "io.micronaut.rabbitmq:micronaut-rabbitmq", version.ref = "managed-micronaut-rabbitmq" }
 managed-micronaut-xml = { module = "io.micronaut.xml:micronaut-jackson-xml", version.ref = "managed-micronaut-xml" }
-
 managed-spock = { module = "org.spockframework:spock-core", version.ref = "managed-spock" }
 managed-spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "managed-spotbugs" }
 


### PR DESCRIPTION
There are still projects which miss BOMs and need to be fixed before releasing 4.0.0:

- Micronaut XML (aka `micronaut-jackson-bom`)
- Micronaut JMS

Those were detected by the module dependency graph checker (see https://micronaut-projects.github.io/module-dependency-graph/)

When running `check` we get the following warning:

```
[Warning] While inlining micronaut-logging-bom-1.0.0-SNAPSHOT.toml, alias 'slf4j-simple' is already defined in the catalog so it won't be imported
[Warning] While inlining micronaut-logging-bom-1.0.0-SNAPSHOT.toml, alias 'logback-classic' is already defined in the catalog so it won't be imported
[Warning] While inlining micronaut-logging-bom-1.0.0-SNAPSHOT.toml, alias 'slf4j-api' is already defined in the catalog so it won't be imported
[Warning] While inlining micronaut-openapi-bom-5.0.0-SNAPSHOT.toml, alias 'slf4j-nop' is already defined in the catalog so it won't be imported
```

Which means that at least a couple other modules are declaring `slf4j-api` and friends as managed, we need to clear that up as there can be a version conflict.