### PR TITLE
Upgrade to Micronaut Build 6.4.0

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/build/internal/RewritePom.java
+++ b/buildSrc/src/main/java/io/micronaut/build/internal/RewritePom.java
@@ -118,7 +118,6 @@ public abstract class RewritePom extends DefaultTask {
         Transformer transf = transformerFactory.newTransformer();
 
         transf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-        transf.setOutputProperty(OutputKeys.INDENT, "yes");
         transf.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
 
         DOMSource source = new DOMSource(doc);

--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
@@ -12,7 +12,6 @@ publishing {
     publications {
         create<MavenPublication>("parent") {
             from(components["javaPlatform"])
-            artifactId = "micronaut-${project.name}"
         }
     }
 }
@@ -36,7 +35,7 @@ generatePomFile.configure {
 }
 
 afterEvaluate {
-    val publishingTasks = setOf("publishParentPublicationToBuildRepository", "publishParentPublicationToSonatypeRepository")
+    val publishingTasks = setOf("publishParentPublicationToMavenLocal", "publishParentPublicationToBuildRepository", "publishParentPublicationToSonatypeRepository")
     tasks.configureEach {
         if (name in publishingTasks)
             dependsOn(rewritePomFile)
@@ -51,4 +50,8 @@ afterEvaluate {
             pom.pomProperties.put(alias.substring(prefix.length).replace(".", "-"), requiredVersion)
         }
     pom.tokenReplacements.put("version", version.toString())
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    enabled = !name.startsWith("publishMaven")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.3.5'
+    id 'io.micronaut.build.shared.settings' version '6.4.0'
 }
 
 rootProject.name = 'micronaut-platform-parent'
@@ -15,6 +15,7 @@ include 'platform'
 include 'parent'
 
 micronautBuild {
+    useStandardizedProjectNames = true
     addSnapshotRepository()
     importMicronautCatalog()
 }


### PR DESCRIPTION
This commit upgrades to build plugins 6.4.0, which fixes the version catalog in order to inline dependency versions too. In addition, this fixes the generated parent file which was adding extra new lines.