### PR TITLE
Fix signing of parent publication

### DIFF
--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
@@ -35,7 +35,11 @@ generatePomFile.configure {
 }
 
 afterEvaluate {
-    val publishingTasks = setOf("publishParentPublicationToMavenLocal", "publishParentPublicationToBuildRepository", "publishParentPublicationToSonatypeRepository")
+    val publishingTasks = setOf(
+        "publishParentPublicationToMavenLocal",
+        "publishParentPublicationToBuildRepository",
+        "publishParentPublicationToSonatypeRepository",
+        "signParentPublication")
     tasks.configureEach {
         if (name in publishingTasks)
             dependsOn(rewritePomFile)
@@ -54,4 +58,8 @@ afterEvaluate {
 
 tasks.withType<PublishToMavenRepository>().configureEach {
     enabled = !name.startsWith("publishMaven")
+}
+
+plugins.withId("signing") {
+    extensions.getByType(SigningExtension::class.java).sign(publishing.publications["parent"])
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.0.0-M1
+projectVersion=4.0.0-SNAPSHOT
 projectGroup=io.micronaut.platform
 
 title=Micronaut Platform


### PR DESCRIPTION
Our convention plugin only configures signing for the `maven` publication.

This should fix the M1 release.