### PR TITLE
Remove validation processor, that is managed via Starter

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -179,11 +179,6 @@
                                 <artifactId>micronaut-inject-java</artifactId>
                                 <version>${micronaut.core.version}</version>
                             </path>
-                            <path>
-                                <groupId>io.micronaut.validation</groupId>
-                                <artifactId>micronaut-validation-processor</artifactId>
-                                <version>${micronaut.validation.version}</version>
-                            </path>
                         </annotationProcessorPaths>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
And in Starter, due to https://github.com/micronaut-projects/micronaut-validation/pull/96#issue-1676343008, we need to generate:

```xml
<path>
  <groupId>io.micronaut.validation</groupId>
  <artifactId>micronaut-validation-processor</artifactId>
  <version>${micronaut.validation.version}</version>
  <exclusions>
    <exclusion>
      <groupId>io.micronaut</groupId>
      <artifactId>micronaut-inject</artifactId>
    </exclusion>
  </exclusions>
</path>
```
