### PR TITLE
Add plugins to parent POM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,8 @@ parent-maven-surefire-plugin = "3.1.2"
 parent-maven-resources-plugin = "3.3.1"
 parent-protoc-jar-maven-plugin = "3.11.4"
 parent-maven-enforcer-plugin = "3.3.0"
+parent-gmavenplus-plugin = "3.0.0"
+parent-jrebel-maven-plugin = "1.2.0"
 
 [libraries]
 # Libraries prefixed with bom- are BOM files
@@ -205,6 +207,8 @@ parent-maven-surefire-plugin = { module = "org.apache.maven.plugins:maven-surefi
 parent-maven-resources-plugin = { module = "org.apache.maven.plugins:maven-resources-plugin", version.ref = "parent-maven-resources-plugin" }
 parent-protoc-jar-maven-plugin = { module = "com.github.os72:protoc-jar-maven-plugin", version.ref = "parent-protoc-jar-maven-plugin" }
 parent-maven-enforcer-plugin = { module = "org.apache.maven.plugins:maven-enforcer-plugin", version.ref = "parent-maven-enforcer-plugin" }
+parent-gmavenplus-plugin = { module = "org.codehaus.gmavenplus:gmavenplus-plugin", version.ref = "parent-gmavenplus-plugin" }
+parent-jrebel-maven-plugin = { module = "org.zeroturnaround:jrebel-maven-plugin", version.ref = "parent-jrebel-maven-plugin" }
 #
 # Other libraries are used by Micronaut but will not appear in the BOM
 #

--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -297,6 +297,42 @@
                         </rules>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>${gmavenplus-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>addSources</goal>
+                                <goal>addTestSources</goal>
+                                <goal>generateStubs</goal>
+                                <goal>compile</goal>
+                                <goal>generateTestStubs</goal>
+                                <goal>compileTests</goal>
+                                <goal>removeStubs</goal>
+                                <goal>removeTestStubs</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.zeroturnaround</groupId>
+                    <artifactId>jrebel-maven-plugin</artifactId>
+                    <version>${jrebel-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>generate-rebel-xml</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>generate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Previously they were hardcoded in Starter.

Also, the configuration we had for `org.codehaus.mojo:properties-maven-plugin` seems unnecessary. We were configuring the following system properties:

* `groovy.target.directory = ${project.build.directory}/classes`.
* `groovy.parameters = true`

However, GMavenPlus has a specific property for [parameters](https://groovy.github.io/GMavenPlus/compile-mojo.html#parameters), and the default [outputDirectory](https://groovy.github.io/GMavenPlus/compile-mojo.html#outputDirectory) is correct.

Fixes: #663