### PR TITLE
Fix publishing to external repository

### DIFF
--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.maven-pom.gradle.kts
@@ -39,6 +39,7 @@ afterEvaluate {
         "publishParentPublicationToMavenLocal",
         "publishParentPublicationToBuildRepository",
         "publishParentPublicationToSonatypeRepository",
+        "publishParentPublicationToExternalRepository",
         "signParentPublication")
     tasks.configureEach {
         if (name in publishingTasks)


### PR DESCRIPTION
Fixes the error 
`Task ':micronaut-parent:publishParentPublicationToExternalRepository' uses this output of task ':micronaut-parent:rewritePomFile' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.`
which occurs when running `./gradlew publish` task.