### PR TITLE
Add version regressions to fix binary compat

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -11,6 +11,13 @@ micronautBom {
     extraExcludedProjects.add("parent")
     suppressions {
 
+        // For 4.1.0, these versions have no `-api` at the end (as they come from micronaut-data, instead of micronaut-sql as previously)
+        // https://github.com/micronaut-projects/micronaut-platform/issues/893
+        acceptedVersionRegressions.addAll(
+            "jakarta-transaction-api",
+            "jakarta-persistence-api",
+        )
+
         // https://github.com/micronaut-projects/micronaut-core/pull/7631#issuecomment-1174702395
         bomAuthorizedGroupIds.put(
                 "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom",


### PR DESCRIPTION
Prior to https://github.com/micronaut-projects/micronaut-data/commit/aa4f7dc0d13a35b746e16a41044f2141c666d146 these versions came from micronaut-sql here

https://github.com/micronaut-projects/micronaut-sql/blob/master/gradle/libs.versions.toml#L48-L49

As you can see, they have `-api` at the end of them.

Now, micronaut-data exports the same dependency names, but the versions for these are lacking an `-api` at the end

https://github.com/micronaut-projects/micronaut-data/blob/master/gradle/libs.versions.toml#L25-L27

As the build tells us, it detects the duplicate and takes the truth from micronaut-data:

> [Warning] While inlining micronaut-sql-bom-5.0.1.toml, alias 'jakarta-transaction-api' is already defined in the catalog by [micronaut-data-bom-4.1.0.toml] so it won't be imported
> [Warning] While inlining micronaut-sql-bom-5.0.1.toml, alias 'jakarta-persistence-api' is already defined in the catalog by [micronaut-data-bom-4.1.0.toml] so it won't be imported

An alternative fix would be to rename the versions in micronaut-data to include an `-api` suffix.