### PR TITLE
Add managed Kotest BOM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ managed-graal-svm = "23.0.1"
 managed-javax-annotation-api = "1.3.2"
 managed-jna = "5.13.0"
 managed-jsr305 = "3.0.2"
+managed-kotest = "5.6.2"
 managed-lombok = "1.18.28"
 managed-maven-native-plugin = "0.9.22"
 managed-micronaut-acme = "4.0.1"
@@ -167,6 +168,7 @@ boms-micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom"
 boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "managed-micronaut-validation" }
 boms-micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", version.ref = "managed-micronaut-views" }
 
+boms-kotest = { module = "io.kotest:kotest-bom", version.ref = "managed-kotest" }
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
 boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
 

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    gradlePluginPortal() // needed for checkBom task to resolve plugin dependencies defined in kotest-pom
 }
 
 micronautBom {


### PR DESCRIPTION
Since version 5, Kotest is shipped with a BOM. 
This bom should be managed because kotest is used and supported in micronaut-test:test-kotest5 module the same way as junit is in micronaut-test:test-junit5.
See also https://github.com/micronaut-projects/micronaut-test/issues/843
Related PR into micronaut-test: https://github.com/micronaut-projects/micronaut-test/pull/844