### PR TITLE
Ensure Native Build Tools are automatically upgraded

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ managed-javax-annotation-api = "1.3.2"
 managed-jna = "5.13.0"
 managed-jsr305 = "3.0.2"
 managed-lombok = "1.18.28"
-managed-maven-native-plugin = "0.9.22"
+managed-maven-native-plugin = "0.9.27"
 managed-micronaut-acme = "4.0.1"
 managed-micronaut-aot = "2.0.1"
 managed-micronaut-aws = "4.0.4"
@@ -166,6 +166,7 @@ boms-micronaut-toml = { module = "io.micronaut.toml:micronaut-toml-bom", version
 boms-micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "managed-micronaut-tracing" }
 boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "managed-micronaut-validation" }
 boms-micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", version.ref = "managed-micronaut-views" }
+boms-micronaut-aot = { module = "io.micronaut.aot:micronaut-aot-bom", version.ref = "managed-micronaut-aot" }
 
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
 boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
@@ -209,6 +210,8 @@ parent-protoc-jar-maven-plugin = { module = "com.github.os72:protoc-jar-maven-pl
 parent-maven-enforcer-plugin = { module = "org.apache.maven.plugins:maven-enforcer-plugin", version.ref = "parent-maven-enforcer-plugin" }
 parent-gmavenplus-plugin = { module = "org.codehaus.gmavenplus:gmavenplus-plugin", version.ref = "parent-gmavenplus-plugin" }
 parent-jrebel-maven-plugin = { module = "org.zeroturnaround:jrebel-maven-plugin", version.ref = "parent-jrebel-maven-plugin" }
+parent-maven-native-plugin = { module = "org.graalvm.buildtools:native-maven-plugin", version.ref = "managed-maven-native-plugin" }
+
 #
 # Other libraries are used by Micronaut but will not appear in the BOM
 #


### PR DESCRIPTION
It also adds a missing dependency for Micronaut AOT.

This is for 4.0.x, will create another one for master