### PR TITLE
Cleanup Parent POM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,6 @@
 # that they will appear in the Micronaut BOM as <properties>
 #
 managed-junit5 = "5.10.0"
-# be sure to update graal version in gradle.properties as well
-# Intentionally pin to 22.0.0.2 see https://github.com/micronaut-projects/micronaut-kafka/pull/564 and https://github.com/micronaut-projects/micronaut-core/pull/7663
-managed-graal-sdk = "23.0.1"
-managed-graal = "22.3.0"
-managed-graal-svm = "23.0.1"
 managed-javax-annotation-api = "1.3.2"
 managed-jna = "5.13.0"
 managed-jsr305 = "3.0.2"
@@ -80,6 +75,11 @@ managed-micronaut-jackson-xml = "4.0.1"
 managed-spock = "2.3-groovy-4.0"
 managed-spotbugs = "4.7.3"
 managed-testcontainers = "1.19.0"
+
+## The following versions are deprecated and must be removed in the next major release
+managed-graal-sdk = "23.0.1"
+managed-graal = "22.3.0"
+managed-graal-svm = "23.0.1"
 
 ## Versions which start with parent- are used to be included in the parent POM as properties
 ## using the following mapping rule:
@@ -174,9 +174,6 @@ boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", versio
 #
 # Libraries which start with managed- are managed by Micronaut in the sense
 # that they will appear in the Micronaut BOM
-#
-managed-graal = { module = "org.graalvm.nativeimage:svm", version.ref = "managed-graal-svm" }
-managed-graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "managed-graal-sdk" }
 
 managed-javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "managed-javax-annotation-api" }
 
@@ -211,6 +208,10 @@ parent-maven-enforcer-plugin = { module = "org.apache.maven.plugins:maven-enforc
 parent-gmavenplus-plugin = { module = "org.codehaus.gmavenplus:gmavenplus-plugin", version.ref = "parent-gmavenplus-plugin" }
 parent-jrebel-maven-plugin = { module = "org.zeroturnaround:jrebel-maven-plugin", version.ref = "parent-jrebel-maven-plugin" }
 parent-maven-native-plugin = { module = "org.graalvm.buildtools:native-maven-plugin", version.ref = "managed-maven-native-plugin" }
+
+# The following dependencies are deprecated and must be removed in the next major release
+managed-graal = { module = "org.graalvm.nativeimage:svm", version.ref = "managed-graal-svm" }
+managed-graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "managed-graal-sdk" }
 
 #
 # Other libraries are used by Micronaut but will not appear in the BOM

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,6 @@
 # that they will appear in the Micronaut BOM as <properties>
 #
 managed-junit5 = "5.10.0"
-# be sure to update graal version in gradle.properties as well
-# Intentionally pin to 22.0.0.2 see https://github.com/micronaut-projects/micronaut-kafka/pull/564 and https://github.com/micronaut-projects/micronaut-core/pull/7663
-managed-graal-sdk = "23.0.1"
-managed-graal = "22.3.0"
-managed-graal-svm = "23.0.1"
 managed-javax-annotation-api = "1.3.2"
 managed-jna = "5.13.0"
 managed-jsr305 = "3.0.2"
@@ -175,9 +170,6 @@ boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", versio
 # Libraries which start with managed- are managed by Micronaut in the sense
 # that they will appear in the Micronaut BOM
 #
-managed-graal = { module = "org.graalvm.nativeimage:svm", version.ref = "managed-graal-svm" }
-managed-graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "managed-graal-sdk" }
-
 managed-javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "managed-javax-annotation-api" }
 
 managed-jna = { module = "net.java.dev.jna:jna", version.ref = "managed-jna" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,11 @@
 # that they will appear in the Micronaut BOM as <properties>
 #
 managed-junit5 = "5.10.0"
+# be sure to update graal version in gradle.properties as well
+# Intentionally pin to 22.0.0.2 see https://github.com/micronaut-projects/micronaut-kafka/pull/564 and https://github.com/micronaut-projects/micronaut-core/pull/7663
+managed-graal-sdk = "23.0.1"
+managed-graal = "22.3.0"
+managed-graal-svm = "23.0.1"
 managed-javax-annotation-api = "1.3.2"
 managed-jna = "5.13.0"
 managed-jsr305 = "3.0.2"
@@ -170,6 +175,9 @@ boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", versio
 # Libraries which start with managed- are managed by Micronaut in the sense
 # that they will appear in the Micronaut BOM
 #
+managed-graal = { module = "org.graalvm.nativeimage:svm", version.ref = "managed-graal-svm" }
+managed-graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "managed-graal-sdk" }
+
 managed-javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "managed-javax-annotation-api" }
 
 managed-jna = { module = "net.java.dev.jna:jna", version.ref = "managed-jna" }

--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -54,19 +54,6 @@
                     <exists>${env.JAVA_HOME}/bin/native-image</exists>
                 </file>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.graalvm.sdk</groupId>
-                    <artifactId>graal-sdk</artifactId>
-                    <version>${graal.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.graalvm.nativeimage</groupId>
-                    <artifactId>svm</artifactId>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -236,10 +223,10 @@
                     <artifactId>native-maven-plugin</artifactId>
                     <version>${maven.native.plugin.version}</version>
                     <extensions>true</extensions>
-                    <configuration combine.self="override">
+                    <configuration>
                         <imageName>${project.artifactId}</imageName>
                         <mainClass>${exec.mainClass}</mainClass>
-                        <buildArgs>
+                        <buildArgs combine.children="append">
                             <buildArg>--no-fallback</buildArg>
                         </buildArgs>
                         <metadataRepository>


### PR DESCRIPTION
This PR cleans up the Parent POM by removing GraalVM dependencies that are now longer needed and were carried over from previous versions.

This targets Platform 4.2.x