### PR TITLE
Revert to Testcontainers 1.19.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,8 @@ managed-micronaut-views = "5.0.1"
 managed-micronaut-jackson-xml = "4.1.0"
 managed-spock = "2.3-groovy-4.0"
 managed-spotbugs = "4.8.1"
-managed-testcontainers = "1.19.2"
+## There's a bug in testcontainers 1.19.2 which causes issues with testresources and mongo/kafka
+managed-testcontainers = "1.19.1"
 
 ## The following versions are deprecated and must be removed in the next major release
 managed-graal-sdk = "23.1.1"


### PR DESCRIPTION
This is the same version we used in 4.1.6, and it worked.

1.19.2 causes errors with Gradle and mongo and test-resources