### PR TITLE
Remove testcontainers from the platform BOM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,8 +74,6 @@ managed-micronaut-views = "5.0.1"
 managed-micronaut-jackson-xml = "4.1.0"
 managed-spock = "2.3-groovy-4.0"
 managed-spotbugs = "4.8.1"
-## There's a bug in testcontainers 1.19.2 which causes issues with testresources and mongo/kafka
-managed-testcontainers = "1.19.1"
 
 ## The following versions are deprecated and must be removed in the next major release
 managed-graal-sdk = "23.1.1"
@@ -170,7 +168,6 @@ boms-micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", vers
 boms-micronaut-aot = { module = "io.micronaut.aot:micronaut-aot-bom", version.ref = "managed-micronaut-aot" }
 
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
-boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
 
 #
 # Libraries which start with managed- are managed by Micronaut in the sense


### PR DESCRIPTION
It's managed in test-resources https://github.com/micronaut-projects/micronaut-test-resources/blob/master/gradle/libs.versions.toml#L55