### PR TITLE
Update Parent POM for Micronaut 4.3

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -181,13 +181,14 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <annotationProcessorPaths>
+                        <annotationProcessorPaths combine.children="append">
                             <path>
                                 <groupId>io.micronaut</groupId>
                                 <artifactId>micronaut-inject-java</artifactId>
                                 <version>${micronaut.core.version}</version>
                             </path>
                         </annotationProcessorPaths>
+                        <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -252,6 +253,7 @@
                         <metadataRepository>
                             <enabled>${graalvm.metadata-repository.enabled}</enabled>
                         </metadataRepository>
+                        <isDetectionEnabled>true</isDetectionEnabled>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -45,6 +45,7 @@
         <exec.executable>java</exec.executable>
         <micronaut.version>%%version%%</micronaut.version>
         <graalvm.metadata-repository.enabled>true</graalvm.metadata-repository.enabled>
+        <resources.autodetection.enabled>true</resources.autodetection.enabled>
     </properties>
     <profiles>
         <profile>
@@ -253,7 +254,7 @@
                         <metadataRepository>
                             <enabled>${graalvm.metadata-repository.enabled}</enabled>
                         </metadataRepository>
-                        <isDetectionEnabled>true</isDetectionEnabled>
+                        <isDetectionEnabled>${resources.autodetection.enabled}</isDetectionEnabled>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
* Enable dependency management for annotation processors (which allows us to remove excludes).
* Enable GraalVM Native Build Tool's resource autodetection.