### PR TITLE
Ignore existing GraalVM resources-config.json files when autodetecting resources

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -46,6 +46,7 @@
         <micronaut.version>%%version%%</micronaut.version>
         <graalvm.metadata-repository.enabled>true</graalvm.metadata-repository.enabled>
         <resources.autodetection.enabled>true</resources.autodetection.enabled>
+        <resources.autodetection.ignoreExistingResourcesConfig>true</resources.autodetection.ignoreExistingResourcesConfig>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
It aligns the behaviour with the Gradle plugin