### PR TITLE
fix(deps): align graalvm versions with micronaut-core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,9 +81,9 @@ managed-spock = "2.3-groovy-4.0"
 managed-spotbugs = "4.8.6"
 
 ## The following versions are deprecated and must be removed in the next major release
-managed-graal-sdk = "24.0.1"
-managed-graal = "22.3.0"
-managed-graal-svm = "24.0.1"
+managed-graal-sdk = "23.1.3"
+managed-graal = "23.1.3"
+managed-graal-svm = "23.1.3"
 
 ## Versions which start with parent- are used to be included in the parent POM as properties
 ## using the following mapping rule:


### PR DESCRIPTION
Align the GraalVM versions of both the SDK and the SVM with the version used in Micronaut-Core. This is the latest version of the 23.x branch which is build with Java 17, while the 24.x branch is build with Java 21.

See https://github.com/micronaut-projects/micronaut-core/issues/10768