### PR TITLE
Configure Failsafe to use the exploded classes directory

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -211,6 +211,9 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
By default, Failsafe uses the packaged JAR of the application under test + all its transitive dependencies. If the project also uses the Shade plugin (which we enable here by default, for the moment), this results in duplicate beans loaded.

Whether using shading or not, there is no advantage in using the packaged JAR, so this PR configures Failsafe to use the exploded classes directory.

cc @alejandropg