### PR TITLE
Fix Shade Plugin exclusion filter

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -232,7 +232,7 @@
                                 </transformers>
                                 <filters>
                                     <filter>
-                                        <artifact>*.*</artifact>
+                                        <artifact>*:*</artifact>
                                         <excludes>
                                             <exclude>META-INF/*.SF</exclude>
                                             <exclude>META-INF/*.DSA</exclude>


### PR DESCRIPTION
Quoting @martijndwars:

> I think the pattern *.* is wrong. The shade plugin splits the pattern on : and interprets it as groupId:artifactId:type:classifier. The pattern *.* then gets interpreted as "groupIds that contain a dot", not as "any artifact". If your dependency tree contains an artifact where the groupId does not contain a dot, it's not filtered out.