### PR TITLE
Updating to Micronaut Gradle Build Plugin breaks docs

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.micronaut.build.internal.publishing:io.micronaut.build.internal.publishing.gradle.plugin:7.6.4")
+    implementation("io.micronaut.build.internal.publishing:io.micronaut.build.internal.publishing.gradle.plugin:7.6.6")
 }
 
 java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        mavenLocal()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,11 +2,12 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        mavenLocal()
     }
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.6.5'
+    id 'io.micronaut.build.shared.settings' version '7.6.6'
 }
 
 rootProject.name = 'micronaut-platform-parent'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.6.4'
+    id 'io.micronaut.build.shared.settings' version '7.6.5'
 }
 
 rootProject.name = 'micronaut-platform-parent'


### PR DESCRIPTION
`./gradlew docs`

```
Starting a Gradle Daemon, 1 busy and 1 incompatible and 4 stopped Daemons could not be reused, use --status for details

> Task :buildSrc:compileJava
Note: /Users/sdelamo/github/micronaut-projects/micronaut-platform/buildSrc/src/main/java/io/micronaut/build/internal/RewritePom.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :publishGuide FAILED

[Incubating] Problems report is available at: file:///Users/sdelamo/github/micronaut-projects/micronaut-platform/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':publishGuide'.
> 'java.util.List org.codehaus.groovy.runtime.ScriptBytecodeAdapter.createRange(java.lang.Object, java.lang.Object, boolean, boolean)'

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins

For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 48s

```