### PR TITLE
fix(deps): update dependency org.testcontainers:testcontainers-bom to v1.21.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ managed-micronaut-views = "5.9.0"
 managed-micronaut-jackson-xml = "4.8.0"
 managed-spock = "2.3-groovy-4.0"
 managed-spotbugs = "4.9.7"
+managed-testcontainers = "1.21.4"
 
 ## The following versions are deprecated and must be removed in the next major release
 managed-graal-sdk = "24.2.2"
@@ -190,6 +191,7 @@ boms-micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", vers
 boms-micronaut-aot = { module = "io.micronaut.aot:micronaut-aot-bom", version.ref = "managed-micronaut-aot" }
 
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
+boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
 
 #
 # Libraries which start with managed- are managed by Micronaut in the sense


### PR DESCRIPTION
## Summary

- Re-introduces `org.testcontainers:testcontainers-bom` into the Micronaut Platform BOM at version `1.21.4`
- Adds `managed-testcontainers = "1.21.4"` to the `[versions]` section of `gradle/libs.versions.toml`
- Adds `boms-testcontainers` library entry referencing the new version

## Test plan

- [x] `./gradlew check` passes locally (including `checkBom` and `checkVersionCatalogCompatibility`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)