### PR TITLE
Exclude Reactor and Kotlin coroutine aliases from platform catalog

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -10,8 +10,7 @@ repositories {
 micronautBom {
     propertyName.set("platform")
     extraExcludedProjects.add("parent")
-    excludeFromInlining(
-        "micronaut-core-bom",
+    excludedInlinedAliases.addAll(
         "boms-kotlin-coroutines",
         "kotlinx-coroutines-*",
         "reactor",

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -10,6 +10,17 @@ repositories {
 micronautBom {
     propertyName.set("platform")
     extraExcludedProjects.add("parent")
+    excludeFromInlining(
+        "micronaut-core-bom",
+        "boms-kotlin-coroutines",
+        "kotlinx-coroutines-*",
+        "reactor",
+        "reactor-test"
+    )
+    excludeFromInlining(
+        "micronaut-reactor-bom",
+        "boms-reactor"
+    )
 
     suppressions {
         // https://github.com/micronaut-projects/micronaut-core/pull/7631#issuecomment-1174702395
@@ -180,6 +191,26 @@ micronautBom {
                 "micronaut-rxjava2",
                 "micronaut-rxjava2-http-client",
                 "micronaut-rxjava2-http-server-netty",
+            )
+        }
+
+        "reactor and kotlin coroutines are provided by module BOMs".apply {
+            acceptedVersionRegressions.addAll(
+                "kotlin-coroutines",
+                "reactor",
+                "reactor-bom"
+            )
+            acceptedLibraryRegressions.addAll(
+                "boms-kotlin-coroutines",
+                "boms-reactor",
+                "kotlinx-coroutines-core",
+                "kotlinx-coroutines-jdk8",
+                "kotlinx-coroutines-reactive",
+                "kotlinx-coroutines-reactor",
+                "kotlinx-coroutines-rx2",
+                "kotlinx-coroutines-slf4j",
+                "reactor",
+                "reactor-test"
             )
         }
 


### PR DESCRIPTION
This removes Reactor and Kotlin coroutine dependency aliases from the generated platform version catalog so consumers use the owning Micronaut module BOMs for those versions instead of relying on `micronaut-platform`.

Changes:
- Exclude Reactor and Kotlin coroutine aliases imported through `micronaut-core-bom`.
- Exclude the external Reactor BOM alias imported through `micronaut-reactor-bom` while keeping the Micronaut Reactor module BOM alias available.
- Record the intentional version-catalog removals as accepted regressions for the 5.0 release line.

Project targeting: `5.0.x`; matching Micronaut organization projects are `5.0.0-M3` and `5.0.0 Release`.

Verification:
- `./gradlew :micronaut-platform:generateCatalogAsToml`
- `./gradlew :micronaut-platform:checkVersionCatalogCompatibility`
- `git diff --check origin/5.0.x...HEAD`
- Confirmed generated catalog lacks top-level `kotlin-coroutines`, `reactor`, `reactor-bom`, `boms-kotlin-coroutines`, `boms-reactor`, `kotlinx-coroutines-*`, and `reactor-test` aliases.

Fixes #31

---
###### ✨ This message was AI-generated using gpt-5