### PR TITLE
Add root AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Micronaut Platform Agent Guidance
+
+This repository publishes the Micronaut Platform BOM, the Gradle version catalog,
+and the Micronaut parent POM. Keep changes focused on dependency alignment,
+release metadata, generated catalog output, and the public documentation that
+explains how users consume the platform.
+
+## Repository Layout
+
+- `gradle/libs.versions.toml` is the source of managed platform versions.
+  Versions prefixed with `managed-` are exposed through the platform BOM, and
+  versions prefixed with `parent-` feed the parent POM.
+- `platform/` owns the platform BOM and Gradle catalog generation. Update
+  `platform/build.gradle.kts` only for BOM behavior, suppressions, accepted
+  regressions, or compatibility checks.
+- `parent/` owns the generated Maven parent POM. Keep parent plugin and property
+  changes aligned with the `parent-*` catalog entries.
+- `src/main/docs/guide/` contains the published guide. `toc.yml` is the guide
+  navigation source of truth; keep it in sync with any added or renamed `.adoc`
+  files.
+
+## Change Rules
+
+- Do not add application code to the root project. The root coordinates the
+  build, documentation, and publication setup.
+- Prefer catalog updates over hard-coded dependency versions in build files.
+- Treat platform version changes as user-visible dependency management changes:
+  check whether `src/main/docs/guide/releaseHistory.adoc` or
+  `src/main/docs/guide/breaks.adoc` needs an entry.
+- Preserve accepted regression and suppression comments in
+  `platform/build.gradle.kts`; add concise rationale when a new suppression is
+  required.
+- Keep synchronized template files, especially `.github/workflows/*`, aligned
+  with `micronaut-project-template` unless the task explicitly asks for a local
+  override.
+
+## Verification
+
+Use the Gradle wrapper. This repository currently builds on Java 25, matching
+the Java CI workflow.
+
+- Full verification: `./gradlew check jacocoReport --no-daemon --continue`
+- Platform BOM/catalog checks: `./gradlew :micronaut-platform:check`
+- Parent POM checks: `./gradlew :micronaut-parent:check`
+- Guide assembly: `./gradlew publishGuide` or `./gradlew pG`
+- Guide plus API docs: `./gradlew docs`
+
+For documentation-only guidance changes, at minimum validate the edited Markdown
+or AsciiDoc and run the smallest Gradle docs task that exercises the changed
+surface when practical.


### PR DESCRIPTION
## Summary

- Add root AGENTS.md guidance for the Micronaut Platform repository.
- Document the platform BOM/catalog and parent POM ownership boundaries.
- Capture repo-specific verification commands and docs layout notes.

## Verification

- ./gradlew -q projects
- ./gradlew publishGuide

---
###### ✨ This message was AI-generated using gpt-5.5
