### PR TITLE
Exclude duplicate html2md converter alias

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -239,6 +239,33 @@ micronautBuild {
 }
 
 tasks {
+    generateCatalogAsToml {
+        doLast {
+            val catalogFile = outputFile.get().asFile
+            val lines = catalogFile.readLines()
+            val newCatalogFile = lines.flatMap {
+                when {
+                    it.startsWith("flexmark = ") && lines.none { line -> line.startsWith("html2md-converter = ") } -> {
+                        val versionPart = it.substringAfterLast(" = ")
+                        listOf(
+                            it,
+                            "# Compatibility alias for the former Micronaut OpenAPI-managed name.",
+                            "html2md-converter = $versionPart"
+                        )
+                    }
+                    it.startsWith("flexmark-html2md-converter = ") && lines.none { line -> line.startsWith("html2md-converter = {") } -> {
+                        listOf(
+                            "# Compatibility alias for the former Micronaut OpenAPI-managed name.",
+                            "html2md-converter = {group = \"com.vladsch.flexmark\", name = \"flexmark-html2md-converter\", version.ref = \"html2md-converter\" }",
+                            it
+                        )
+                    }
+                    else -> listOf(it)
+                }
+            }
+            catalogFile.writeText(newCatalogFile.joinToString("\n"))
+        }
+    }
     // This is a workaround for the `jackson-databind` version being removed from the catalog
     // because it's not referenced anywhere anymore. However we must keep it for backwards
     // compatibility. This canbe removed after the next major release.

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -20,6 +20,7 @@ micronautBom {
         "micronaut-reactor-bom",
         "boms-reactor"
     )
+    excludeFromInlining("micronaut-openapi-bom", "html2md-converter")
 
     suppressions {
         // https://github.com/micronaut-projects/micronaut-core/pull/7631#issuecomment-1174702395


### PR DESCRIPTION
Fixes the generated platform BOM metadata by excluding the deprecated `html2md-converter` alias from the inlined Micronaut OpenAPI BOM catalog. The canonical `flexmark-html2md-converter` alias remains managed through `${flexmark.version}`, so the dependency coordinate is still present but no longer duplicated in `dependencyManagement`.

The compatibility `html2md-converter` alias is kept in the generated version catalog (pointing at the same `com.vladsch.flexmark:flexmark-html2md-converter` coordinate) so catalog consumers are not broken.

## Verification

Re-verified on head `921385f513edb1320b3cea943f259de7cbaddebd`, after merging the repaired `5.2.x` (`c0c2d989`) up into this branch:

- `./gradlew :micronaut-platform:verifyPlatformMigrationImpactAppendix :micronaut-platform:generatePomFileForMavenPublication :micronaut-platform:generateCatalogAsToml` &rarr; `BUILD SUCCESSFUL`, with `verifyPlatformMigrationImpactAppendix` actually executed.
- `platform/build/publications/maven/pom-default.xml` now contains exactly one `com.vladsch.flexmark:flexmark-html2md-converter` `dependencyManagement` entry, resolved through `${flexmark.version}`. The duplicate `${html2md.converter.version}` entry reported in #2410 is gone.
- Generated `platform/build/version-catalog/libs.versions.toml` still exposes both the canonical `flexmark-html2md-converter` alias and the compatibility `html2md-converter` alias.

The `build (25)` failure previously reported on this PR was a `5.2.x` baseline break (`:micronaut-platform:verifyPlatformMigrationImpactAppendix`, missing migration-impact row for `micronaut-micrometer-registry-wavefront`), not a defect in this change. It was repaired separately on `5.2.x` in #2811 and is cleared here by the merge-up.

The net diff of this PR against `5.2.x` remains limited to `platform/build.gradle.kts`.

Closes #2410

---
###### ✨ This pull request description was AI-generated using claude-opus-5