### PR TITLE
Fix Netty Maven version override in platform BOM

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -1,3 +1,14 @@
+import java.io.File
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import org.gradle.api.Project
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
 plugins {
     id("io.micronaut.build.internal.bom")
 }
@@ -208,6 +219,14 @@ micronautBuild {
 }
 
 tasks {
+    val generatedMavenPom = layout.buildDirectory.file("publications/maven/pom-default.xml")
+
+    named("generatePomFileForMavenPublication") {
+        doLast {
+            configureNettyBomImport(generatedMavenPom.get().asFile)
+        }
+    }
+
     // This is a workaround for the `jackson-databind` version being removed from the catalog
     // because it's not referenced anywhere anymore. However we must keep it for backwards
     // compatibility. This canbe removed after the next major release.
@@ -234,4 +253,168 @@ tasks {
             println(current.get().asFile)
         }
     }
+
+    val checkNettyBomImport by registering {
+        description = "Verifies the published Maven platform POM exposes an overrideable Netty BOM import."
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOn("generatePomFileForMavenPublication")
+        inputs.file(generatedMavenPom)
+
+        doLast {
+            val factory = DocumentBuilderFactory.newInstance()
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            val document = factory.newDocumentBuilder().parse(generatedMavenPom.get().asFile)
+            val properties = document.getElementsByTagName("properties").item(0) as Element
+            val nettyVersion = properties.getElementsByTagName("netty.version").item(0)?.textContent
+            check(!nettyVersion.isNullOrBlank()) {
+                "Expected generated Maven POM to expose a netty.version property"
+            }
+
+            var importedNettyBomIndex = -1
+            var importedMicronautCoreBomIndex = -1
+            val dependencies = document.getElementsByTagName("dependency")
+            for (i in 0 until dependencies.length) {
+                val dependency = dependencies.item(i) as Element
+                val groupId = dependency.childText("groupId")
+                val artifactId = dependency.childText("artifactId")
+                if (groupId == "io.netty" && artifactId == "netty-bom") {
+                    val isImport = dependency.childText("type") == "pom" && dependency.childText("scope") == "import"
+                    if (isImport) {
+                        check(dependency.childText("version") == "\${netty.version}") {
+                            "Expected imported io.netty:netty-bom to use \${netty.version}"
+                        }
+                        importedNettyBomIndex = i
+                    }
+                }
+                if (groupId == "io.micronaut" &&
+                    artifactId == "micronaut-core-bom" &&
+                    dependency.childText("type") == "pom" &&
+                    dependency.childText("scope") == "import") {
+                    importedMicronautCoreBomIndex = i
+                }
+            }
+
+            check(importedNettyBomIndex >= 0) {
+                "Expected generated Maven POM to import io.netty:netty-bom"
+            }
+            check(importedMicronautCoreBomIndex < 0 || importedNettyBomIndex < importedMicronautCoreBomIndex) {
+                "Expected io.netty:netty-bom import to appear before micronaut-core-bom"
+            }
+        }
+    }
+
+    check {
+        dependsOn(checkNettyBomImport)
+    }
+}
+
+private fun Project.configureNettyBomImport(pomFile: File) {
+    val document = parseXml(pomFile)
+    val project = document.documentElement
+    val properties = project.childElement("properties")
+        ?: error("Expected generated Maven POM to contain project properties")
+    val micronautCoreVersion = properties.childText("micronaut.core.version")
+        ?: error("Expected generated Maven POM to expose micronaut.core.version")
+    val nettyVersion = resolveMicronautCoreNettyVersion(micronautCoreVersion)
+
+    properties.ensureChildText("netty.version", nettyVersion)
+
+    val dependencyManagement = project.childElement("dependencyManagement")
+        ?: error("Expected generated Maven POM to contain dependencyManagement")
+    val dependencies = dependencyManagement.childElement("dependencies")
+        ?: error("Expected generated Maven POM to contain dependencyManagement dependencies")
+    val micronautCoreBom = dependencies.dependency("io.micronaut", "micronaut-core-bom", importBom = true)
+        ?: error("Expected generated Maven POM to import micronaut-core-bom")
+
+    dependencies.childElements("dependency")
+        .filter { it.isDependency("io.netty", "netty-bom", importBom = true) }
+        .forEach { dependencies.removeChild(it) }
+
+    dependencies.insertBefore(
+        document.createDependency("io.netty", "netty-bom", "\${netty.version}", importBom = true),
+        micronautCoreBom
+    )
+    writeXml(document, pomFile)
+}
+
+private fun Project.resolveMicronautCoreNettyVersion(micronautCoreVersion: String): String {
+    val coreBomPom = configurations.detachedConfiguration(
+        dependencies.create("io.micronaut:micronaut-core-bom:$micronautCoreVersion@pom")
+    ).singleFile
+    val properties = parseXml(coreBomPom).documentElement.childElement("properties")
+        ?: error("Expected micronaut-core-bom $micronautCoreVersion to contain properties")
+    return properties.childText("netty.version")
+        ?: error("Expected micronaut-core-bom $micronautCoreVersion to expose netty.version")
+}
+
+private fun Element.childText(tagName: String): String? =
+    getElementsByTagName(tagName).item(0)?.textContent
+
+private fun parseXml(file: File) = DocumentBuilderFactory.newInstance()
+    .also { it.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) }
+    .newDocumentBuilder()
+    .parse(file)
+
+private fun writeXml(document: org.w3c.dom.Document, file: File) {
+    document.removeBlankTextNodes()
+    val transformer = TransformerFactory.newInstance().newTransformer()
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8")
+    transformer.setOutputProperty(OutputKeys.METHOD, "xml")
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes")
+    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+    transformer.transform(DOMSource(document), StreamResult(file))
+}
+
+private fun Node.removeBlankTextNodes() {
+    for (i in childNodes.length - 1 downTo 0) {
+        val child = childNodes.item(i)
+        if (child.nodeType == Node.TEXT_NODE && child.textContent.isBlank()) {
+            removeChild(child)
+        } else {
+            child.removeBlankTextNodes()
+        }
+    }
+}
+
+private fun Element.childElement(tagName: String): Element? =
+    childElements(tagName).firstOrNull()
+
+private fun Element.childElements(tagName: String): List<Element> =
+    (0 until childNodes.length)
+        .map { childNodes.item(it) }
+        .filterIsInstance<Element>()
+        .filter { it.tagName == tagName }
+
+private fun Element.ensureChildText(tagName: String, text: String) {
+    val element = childElement(tagName) ?: ownerDocument.createElement(tagName).also { appendChild(it) }
+    element.textContent = text
+}
+
+private fun Element.dependency(groupId: String, artifactId: String, importBom: Boolean = false): Element? =
+    childElements("dependency").firstOrNull { it.isDependency(groupId, artifactId, importBom) }
+
+private fun Element.isDependency(groupId: String, artifactId: String, importBom: Boolean = false): Boolean =
+    childText("groupId") == groupId &&
+        childText("artifactId") == artifactId &&
+        (!importBom || childText("type") == "pom" && childText("scope") == "import")
+
+private fun org.w3c.dom.Document.createDependency(
+    groupId: String,
+    artifactId: String,
+    version: String,
+    importBom: Boolean = false
+): Node {
+    val dependency = createElement("dependency")
+    dependency.appendTextElement("groupId", groupId)
+    dependency.appendTextElement("artifactId", artifactId)
+    dependency.appendTextElement("version", version)
+    if (importBom) {
+        dependency.appendTextElement("type", "pom")
+        dependency.appendTextElement("scope", "import")
+    }
+    return dependency
+}
+
+private fun Element.appendTextElement(tagName: String, text: String) {
+    appendChild(ownerDocument.createElement(tagName).also { it.textContent = text })
 }


### PR DESCRIPTION
## Summary

Fixes #2399.

- publish an imported `io.netty:netty-bom` in the platform Maven BOM using `${netty.version}`
- derive the generated platform `netty.version` property from the configured `io.micronaut:micronaut-core-bom`, keeping Micronaut core as the Netty version owner
- add a generated-POM verification task wired into `:micronaut-platform:check` so the Netty BOM import stays overrideable and ahead of `micronaut-core-bom`

## Verification

- `./gradlew :micronaut-platform:generatePomFileForMavenPublication :micronaut-platform:checkNettyBomImport :micronaut-parent:rewritePomFile :micronaut-platform:checkBom :micronaut-platform:checkVersionCatalogCompatibility --quiet`
- `./gradlew :micronaut-platform:publishMavenPublicationToMavenLocal :micronaut-parent:publishParentPublicationToMavenLocal --quiet`
- Dockerized Maven parent reproducer with `<netty.version>4.2.11.Final</netty.version>` resolved every `io.netty:*:jar` artifact to `4.2.11.Final`
- `./gradlew -q :micronaut-platform:check`
- `git diff --check origin/5.0.x...HEAD`

## Release Target

QA selected `5.0.0-M3` and `5.0.0 Release`. Ambiguity preserved from intake: latest stable `4.10.13` reproduces and `4.10.14 Release` is open, but this PR targets the current default `5.0.x`; any 4.10.x backport is a separate release-governance decision.

---
###### ✨ This message was AI-generated using gpt-5.5