### PR TITLE
Preserve multi-release manifest in shaded jars

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -235,6 +235,9 @@
                                 <transformers>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${exec.mainClass}</mainClass>
+                                        <manifestEntries>
+                                            <Multi-Release>true</Multi-Release>
+                                        </manifestEntries>
                                     </transformer>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 </transformers>


### PR DESCRIPTION
This updates the Micronaut parent managed Shade default so executable shaded JARs preserve the multi-release manifest marker needed by GraalVM Truffle/GraalPy dependencies.

The existing `default-shade` execution already owns the manifest transformer that sets `${exec.mainClass}`. This change adds `Multi-Release: true` to that same transformer while preserving the services transformer, `createDependencyReducedPom=false`, and the existing signature/module-info exclusions.

Fixes micronaut-projects/micronaut-maven-plugin#1651

Target projects: `5.0.0-M3` and `5.0.0 Release`. QA noted that `5.0.0-M3` was already published on 2026-04-29 but its project remains open, so both selected boards are intentionally carried forward unless maintainers retarget.

Verification:
- `./gradlew :micronaut-parent:check --console=plain`
- `./gradlew :micronaut-parent:generatePomFileForParentPublication --console=plain`
- `./gradlew publishToMavenLocal --console=plain`
- `./gradlew publishAllPublicationsToBuildRepository --console=plain`
- Temporary Maven fixture using generated `io.micronaut.platform:micronaut-parent:5.0.0-SNAPSHOT`, no app-level Shade override, and a multi-release dependency produced a shaded runnable JAR whose manifest contains `Multi-Release: true`; `java -jar` printed `ok`.

---
###### ✨ This message was AI-generated using GPT-5
