### PR TITLE
Document Kotlin Maven support removal

### DIFF
--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -6,3 +6,9 @@ This section documents breaking changes between Micronaut versions
 
 - `micronaut-microstream` has been removed from the Micronaut platform.
 - `micronaut-rxjava2` has been removed from the Micronaut platform.
+
+=== Build Tool Support
+
+Starting with Micronaut Platform 5.0, Kotlin applications built with Maven are not supported. This support-policy change is limited to the Kotlin and Maven combination: Java applications built with Maven remain supported, and Kotlin applications built with Gradle remain supported.
+
+Kotlin Micronaut applications should move to Gradle when upgrading to Micronaut Platform 5.0 or later. Applications that require Maven with Kotlin should remain on a supported Micronaut 4.x release line until they can migrate their build.

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -6,6 +6,8 @@ It aggregates many of the individual Micronaut module BOMs and provides a single
 
 If you use either the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Micronaut Gradle Plugin] or the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Micronaut Maven Plugin], you do not need to add this module to your project as it will be added automatically.
 
+NOTE: Starting with Micronaut Platform 5.0, Kotlin applications built with Maven are not supported. Java applications built with Maven remain supported, and Kotlin applications built with Gradle remain supported.
+
 NOTE: The Micronaut Platform BOM exists since Micronaut Framework 4, and corresponds to the Micronaut Framework  3 BOM which was published at `io.micronaut:micronaut-bom`. In Micronaut 4, we provide both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`).
 
 == The Micronaut Platform catalog


### PR DESCRIPTION
## Summary

- Document that Micronaut Platform 5.0 does not support Kotlin applications built with Maven.
- Clarify that Java applications built with Maven and Kotlin applications built with Gradle remain supported.
- Add 5.0 breaking-change migration guidance for Kotlin Maven users.

Closes #1075.

## Validation

- `git diff --check HEAD~1..HEAD`
- `./gradlew publishGuide` (QA rerun passed)
- `./gradlew docs` (Technical Writer artifact records passed)

## Paperclip

- DEV-151
- Approved board decision: `6599d16e-8df5-45ea-bd35-33cf7a9f186a`
- Project targeting: `5.0.0-M3` and `5.0.0 Release`
- Ambiguity note: QA selected both the next milestone board and the GA release board because this breaking support-policy change targets the `5.0.x` default branch before stable 5.0 GA.

---
###### ✨ This message was AI-generated using gpt-5