### PR TITLE
Fix Platform contributing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,22 @@
 # Contributing Code or Documentation to Micronaut
 
-Sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/micronaut-projects/micronaut-bom). This is required before any of your code or pull-requests are accepted.
+Sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/micronaut-projects/micronaut-platform). This is required before any of your code or pull requests are accepted.
 
 ## Finding Issues to Work on
 
-If you are interested in contributing to Micronaut and are looking for issues to work on, take a look at the issues tagged with [help wanted](https://github.com/micronaut-projects/micronaut-xxx/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+help+wanted%22).
+If you are interested in contributing to Micronaut and are looking for issues to work on, take a look at the issues tagged with [help wanted](https://github.com/micronaut-projects/micronaut-platform/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+help+wanted%22).
 
 ## JDK Setup
 
-Micronaut project-template currently requires JDK 8.
+Micronaut Platform currently requires Java 25. Use the version in `.sdkmanrc` with SDKMAN, or install a Java 25 distribution compatible with the Gradle wrapper.
 
 ## IDE Setup
 
-Micronaut project-template can be imported into IntelliJ IDEA by opening the `build.gradle` file.
+Micronaut Platform can be imported into IntelliJ IDEA by opening the `settings.gradle` file.
 
 ## Docker Setup
 
-Micronaut project-template tests currently require Docker to be installed.
+The standard Micronaut Platform build does not currently require Docker.
 
 ## Running Tests
 
@@ -32,9 +32,9 @@ To also build the Javadocs, run `./gradlew docs`.
 
 ## Working on the code base
 
-If you use IntelliJ IDEA, you can import the project using the Intellij Gradle Tooling ("File / Import Project" and selecting the "settings.gradle" file).
+If you use IntelliJ IDEA, you can import the project using the IntelliJ Gradle Tooling ("File / Import Project" and selecting the `settings.gradle` file).
 
-To get a local development version of Micronaut XXX working, first run the `publishToMavenLocal` task.
+To publish a local development version of Micronaut Platform, first run the `publishToMavenLocal` task.
 
 ```
 ./gradlew pTML
@@ -59,13 +59,13 @@ Once you are satisfied with your changes:
 
 ## Merging a pull request
 
-Before we merge into a module's `master` branch a PR, we have to consider.
+Before we merge a PR into a module's `master` branch, we have to consider:
 
-Can this PR be merged into a patch release (e.g. documentation fixes, bug fix, patch transitive dependency upgrade, breaking change due to security, Github actions sync, Micronaut Build Plugin upgrade)?
+Can this PR be merged into a patch release (e.g. documentation fixes, bug fix, patch transitive dependency upgrade, breaking change due to security, GitHub Actions sync, Micronaut Build Plugin upgrade)?
 
 Should this PR be merged into the next minor version of the module? For example, a new feature, a new module, or a minor transitive dependency upgrade.
 
-If the PR is going into the next minor version of the module, we need to release a patch version, and branch off `master` a new branch for the current minor module's version. If the `gradle.properties`'s `projectVersion` is 3.1.2-SNAPSHOT the branch should be named 3.1.x, and we push it to Github. If `master` contains only commits such as Github actions sync (no commits with benefits to users), we can branch off without doing a patch release.
+If the PR is going into the next minor version of the module, we need to release a patch version, and branch off `master` a new branch for the current minor module's version. If the `gradle.properties`'s `projectVersion` is 3.1.2-SNAPSHOT, the branch should be named 3.1.x, and we push it to GitHub. If `master` contains only commits such as GitHub Actions sync (no commits with benefits to users), we can branch off without doing a patch release.
 
 When you merge a PR which will go into the next Module's minor.
 
@@ -77,13 +77,13 @@ When you merge a PR which will go into the next Module's minor.
 
 We want to keep the code clean, following good practices about organization, Javadoc, and style as much as possible.
 
-Micronaut XXX uses [Checkstyle](https://checkstyle.sourceforge.io/) to make sure that the code follows those standards. The configuration is defined in `config/checkstyle/checkstyle.xml`. To execute Checkstyle, run:
+Micronaut Platform uses [Checkstyle](https://checkstyle.sourceforge.io/) to make sure that the code follows those standards. The configuration is defined in `config/checkstyle/checkstyle.xml`. To execute Checkstyle for a module, run:
 
 ```
 ./gradlew <module-name>:checkstyleMain
 ```
 
-Before starting to contribute new code we recommended that you install the IntelliJ [CheckStyle-IDEA](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) plugin and configure it to use Micronaut's checkstyle configuration file.
+Before starting to contribute new code, we recommend that you install the IntelliJ [CheckStyle-IDEA](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) plugin and configure it to use Micronaut's checkstyle configuration file.
 
 IntelliJ will mark in red the issues Checkstyle finds. For example:
 
@@ -93,6 +93,6 @@ In this case, to fix the issues, we need to:
 
 - Add one empty line before `package` in line 16
 - Add the Javadoc for the constructor in line 27
-- Add an space after `if` in line 34
+- Add a space after `if` in line 34
 
 The plugin also adds a new tab in the bottom of the IDE to run Checkstyle and show errors and warnings. We recommend that you run the report and fix all issues before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=micronaut-projects_micronaut-platform&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=micronaut-projects_micronaut-platform)
 [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.micronaut.io/scans)
 
-Micronaut project-template
+Bill of Materials (BOM) and Gradle version catalogs for Micronaut projects.
 
 ## Documentation
 
@@ -17,15 +17,15 @@ See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-
 
 ## Snapshots and Releases
 
-Snapshots are automatically published to [Sonatype Snapshots](https://s01.oss.sonatype.org/content/repositories/snapshots/io/micronaut/) using [Github Actions](https://github.com/micronaut-projects/micronaut-platform/actions).
+Snapshots are automatically published to [Sonatype Snapshots](https://s01.oss.sonatype.org/content/repositories/snapshots/io/micronaut/) using [GitHub Actions](https://github.com/micronaut-projects/micronaut-platform/actions).
 
 See the documentation in the [Micronaut Docs](https://docs.micronaut.io/latest/guide/index.html#usingsnapshots) for how to configure your build to use snapshots.
 
-Releases are published to Maven Central via [Github Actions](https://github.com/micronaut-projects/micronaut-platform/actions).
+Releases are published to Maven Central via [GitHub Actions](https://github.com/micronaut-projects/micronaut-platform/actions).
 
 Releases are completely automated. To perform a release use the following steps:
 
-* [Publish the draft release](https://github.com/micronaut-projects/micronaut-bom/releases). There should be already a draft release created, edit and publish it. The Git Tag should start with `v`. For example `v1.0.0`.
-* [Monitor the Workflow](https://github.com/micronaut-projects/micronaut-bom/actions?query=workflow%3ARelease) to check it passed successfully.
-* If everything went fine, [publish to Maven Central](https://github.com/micronaut-projects/micronaut-bom/actions?query=workflow%3A"Maven+Central+Sync").
+* [Publish the draft release](https://github.com/micronaut-projects/micronaut-platform/releases). There should be already a draft release created, edit and publish it. The Git Tag should start with `v`. For example `v1.0.0`.
+* [Monitor the Workflow](https://github.com/micronaut-projects/micronaut-platform/actions?query=workflow%3ARelease) to check it passed successfully.
+* If everything went fine, [publish to Maven Central](https://github.com/micronaut-projects/micronaut-platform/actions?query=workflow%3A"Maven+Central+Sync").
 * Celebrate!


### PR DESCRIPTION
## Summary
- Update `CONTRIBUTING.md` for the Platform repository: CLA/help-wanted links, Java 25 setup, IDE import, Docker expectation, local publishing, merge wording, and Checkstyle placeholder text.
- Fix the root README's copied template sentence and release workflow links so they point at `micronaut-platform`.

## Verification
- `git diff --check`
- Checked for stale `project-template`, `micronaut-xxx`, `Micronaut XXX`, `JDK 8`, and `JDK 21` guidance in the touched root docs.
- `./gradlew help --no-daemon`

---
###### ✨ This message was AI-generated using gpt-5.5
