### PR TITLE
docs: fix platform guide and README metadata

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -8,7 +8,7 @@ If you use either the https://micronaut-projects.github.io/micronaut-gradle-plug
 
 NOTE: Starting with Micronaut Platform 5.0, Kotlin applications built with Maven are not supported. Java applications built with Maven remain supported, and Kotlin applications built with Gradle remain supported.
 
-NOTE: The Micronaut Platform BOM exists since Micronaut Framework 4, and corresponds to the Micronaut Framework  3 BOM which was published at `io.micronaut:micronaut-bom`. In Micronaut 4, we provide both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`).
+NOTE: The Micronaut Platform BOM has existed since Micronaut Framework 4, and corresponds to the Micronaut Framework 3 BOM which was published at `io.micronaut:micronaut-bom`. In Micronaut 4, we provide both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`).
 
 == The Micronaut Platform catalog
 


### PR DESCRIPTION
Summary:
- Clean up the Platform BOM note in the generated user guide introduction.
- Resolve merge conflicts with the current `5.0.x` branch; upstream already contains the README metadata fixes originally included in this PR.

Validation:
- `./gradlew publishGuide`
- `./gradlew docs`

Conflict resolution:
- Preserved the upstream Micronaut Platform 5.0 Kotlin/Maven support note.
- Kept the BOM wording cleanup and removed the extra spacing in the Micronaut Framework 3 BOM sentence.

Paperclip: DEV-298

---
###### ✨ This message was AI-generated using gpt-5.5
