### PR TITLE
Update BOM checker suppressions

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.micronaut.build.internal.publishing:io.micronaut.build.internal.publishing.gradle.plugin:8.0.0-M18")
+    implementation("io.micronaut.build.internal.publishing:io.micronaut.build.internal.publishing.gradle.plugin:8.0.0-RC1")
 }
 
 java {

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -63,6 +63,10 @@ micronautBom {
             "io.projectreactor:reactor-bom",
             setOf("io.projectreactor", "org.reactivestreams")
         )
+        bomAuthorizedGroupIds.put(
+            "tools.jackson:jackson-bom",
+            setOf("com.fasterxml.jackson.core", "tools.jackson")
+        )
         // micronaut-oraclecloud (since v3.6.0) pulls in the ojdbc-bom which imports dependencies from many groups
         bomAuthorizedGroupIds.put(
             "com.oracle.database.jdbc:ojdbc-bom",
@@ -80,8 +84,9 @@ micronautBom {
         dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.0.3")
 
         dependencies.add("io.opentelemetry:opentelemetry-bom:1.61.0")
-        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.40.0-alpha")
+        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.61.0-alpha")
         dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.27.0")
+        dependencies.add("io.opentelemetry.semconv:opentelemetry-semconv:1.40.0")
 
         // modules no longer published by the OCI SDK
         acceptedLibraryRegressions.add("micronaut-oraclecloud-bmc-applicationmigration")

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '8.0.0-M18'
+    id 'io.micronaut.build.shared.settings' version '8.0.0-RC1'
 }
 
 rootProject.name = 'micronaut-platform-parent'


### PR DESCRIPTION
## Summary
- authorize the Jackson 3 BOM to manage both tools.jackson and com.fasterxml.jackson.core artifacts
- update OpenTelemetry alpha BOM suppression to the currently managed version
- add the semconv artifact suppression required by the updated OpenTelemetry instrumentation BOM

Depends on micronaut-build PR: https://github.com/micronaut-projects/micronaut-build/pull/890

## Testing
- > Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:generateExternalPluginSpecBuilders UP-TO-DATE
> Task :buildSrc:extractPrecompiledScriptPluginPlugins UP-TO-DATE
> Task :buildSrc:compilePluginsBlocks UP-TO-DATE
> Task :buildSrc:generatePrecompiledScriptPluginAccessors UP-TO-DATE
> Task :buildSrc:generateScriptPluginAdapters UP-TO-DATE
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava UP-TO-DATE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Task :micronaut-platform:generatePomFileForMavenPublication
Projects included into BOM:
    - :micronaut-parent
Inlining log file: /Users/alvaro/Dev/micronaut-projects/micronaut-platform/platform/build/logs/inlining-1778577688566.log

> Task :micronaut-platform:checkBom UP-TO-DATE

BUILD SUCCESSFUL in 1s
12 actionable tasks: 1 executed, 11 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html
