### PR TITLE
Add generic Maven BOM override imports

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation("io.micronaut.build.internal.publishing:io.micronaut.build.internal.publishing.gradle.plugin:8.0.0")
     implementation("org.tomlj:tomlj:1.1.1")
+    testImplementation(gradleTestKit())
     testImplementation(kotlin("test"))
 }
 

--- a/buildSrc/src/main/kotlin/io/micronaut/platform/pom/OverrideableBomImports.kt
+++ b/buildSrc/src/main/kotlin/io/micronaut/platform/pom/OverrideableBomImports.kt
@@ -1,0 +1,202 @@
+package io.micronaut.platform.pom
+
+import java.io.File
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import org.gradle.api.Project
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+/**
+ * Allowlisted external BOM import that keeps Maven child property overrides
+ * coherent for dependency families owned by imported Micronaut BOMs.
+ */
+data class OverrideableBomImport(
+    val propertyName: String,
+    val importedBomGroupId: String,
+    val importedBomArtifactId: String,
+    val owningBomGroupId: String,
+    val owningBomArtifactId: String,
+    val owningBomVersionProperty: String
+)
+
+fun Project.configureOverrideableBomImports(
+    pomFile: File,
+    imports: List<OverrideableBomImport>
+) {
+    val document = parseXml(pomFile)
+    val project = document.documentElement
+    val properties = project.childElement("properties")
+        ?: error("Expected generated Maven POM to contain project properties")
+    val dependencyManagement = project.childElement("dependencyManagement")
+        ?: error("Expected generated Maven POM to contain dependencyManagement")
+    val dependencies = dependencyManagement.childElement("dependencies")
+        ?: error("Expected generated Maven POM to contain dependencyManagement dependencies")
+
+    imports.forEach { import ->
+        val owningBomVersion = properties.childText(import.owningBomVersionProperty)
+            ?: error("Expected generated Maven POM to expose ${import.owningBomVersionProperty}")
+        val propertyValue = resolvePomProperty(
+            import.owningBomGroupId,
+            import.owningBomArtifactId,
+            owningBomVersion,
+            import.propertyName
+        )
+
+        properties.ensureChildText(import.propertyName, propertyValue)
+
+        val owningBom = dependencies.dependency(
+            import.owningBomGroupId,
+            import.owningBomArtifactId,
+            importBom = true
+        ) ?: error("Expected generated Maven POM to import ${import.owningBomGroupId}:${import.owningBomArtifactId}")
+
+        dependencies.childElements("dependency")
+            .filter { it.isDependency(import.importedBomGroupId, import.importedBomArtifactId, importBom = true) }
+            .forEach { dependencies.removeChild(it) }
+
+        dependencies.insertBefore(
+            document.createDependency(
+                import.importedBomGroupId,
+                import.importedBomArtifactId,
+                "\${${import.propertyName}}",
+                importBom = true
+            ),
+            owningBom
+        )
+    }
+
+    writeXml(document, pomFile)
+}
+
+fun Project.checkOverrideableBomImports(
+    pomFile: File,
+    imports: List<OverrideableBomImport>
+) {
+    val document = parseXml(pomFile)
+    val properties = document.getElementsByTagName("properties").item(0) as Element
+    val dependencies = document.getElementsByTagName("dependency")
+
+    imports.forEach { import ->
+        val propertyValue = properties.getElementsByTagName(import.propertyName).item(0)?.textContent
+        check(!propertyValue.isNullOrBlank()) {
+            "Expected generated Maven POM to expose ${import.propertyName}"
+        }
+
+        var importedBomIndex = -1
+        var owningBomIndex = -1
+        for (i in 0 until dependencies.length) {
+            val dependency = dependencies.item(i) as Element
+            if (dependency.isDependency(import.importedBomGroupId, import.importedBomArtifactId)) {
+                val isImport = dependency.childText("type") == "pom" && dependency.childText("scope") == "import"
+                if (isImport) {
+                    check(dependency.childText("version") == "\${${import.propertyName}}") {
+                        "Expected imported ${import.importedBomGroupId}:${import.importedBomArtifactId} to use \${${import.propertyName}}"
+                    }
+                    importedBomIndex = i
+                }
+            }
+            if (dependency.isDependency(import.owningBomGroupId, import.owningBomArtifactId, importBom = true)) {
+                owningBomIndex = i
+            }
+        }
+
+        check(importedBomIndex >= 0) {
+            "Expected generated Maven POM to import ${import.importedBomGroupId}:${import.importedBomArtifactId}"
+        }
+        check(owningBomIndex < 0 || importedBomIndex < owningBomIndex) {
+            "Expected ${import.importedBomGroupId}:${import.importedBomArtifactId} import to appear before ${import.owningBomGroupId}:${import.owningBomArtifactId}"
+        }
+    }
+}
+
+private fun Project.resolvePomProperty(
+    groupId: String,
+    artifactId: String,
+    version: String,
+    propertyName: String
+): String {
+    val pomFile = configurations.detachedConfiguration(
+        dependencies.create("$groupId:$artifactId:$version@pom")
+    ).singleFile
+    val properties = parseXml(pomFile).documentElement.childElement("properties")
+        ?: error("Expected $groupId:$artifactId:$version to contain properties")
+    return properties.childText(propertyName)
+        ?: error("Expected $groupId:$artifactId:$version to expose $propertyName")
+}
+
+private fun Element.childText(tagName: String): String? =
+    getElementsByTagName(tagName).item(0)?.textContent
+
+private fun parseXml(file: File) = DocumentBuilderFactory.newInstance()
+    .also { it.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) }
+    .newDocumentBuilder()
+    .parse(file)
+
+private fun writeXml(document: org.w3c.dom.Document, file: File) {
+    document.removeBlankTextNodes()
+    val transformer = TransformerFactory.newInstance().newTransformer()
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8")
+    transformer.setOutputProperty(OutputKeys.METHOD, "xml")
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes")
+    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+    transformer.transform(DOMSource(document), StreamResult(file))
+}
+
+private fun Node.removeBlankTextNodes() {
+    for (i in childNodes.length - 1 downTo 0) {
+        val child = childNodes.item(i)
+        if (child.nodeType == Node.TEXT_NODE && child.textContent.isBlank()) {
+            removeChild(child)
+        } else {
+            child.removeBlankTextNodes()
+        }
+    }
+}
+
+private fun Element.childElement(tagName: String): Element? =
+    childElements(tagName).firstOrNull()
+
+private fun Element.childElements(tagName: String): List<Element> =
+    (0 until childNodes.length)
+        .map { childNodes.item(it) }
+        .filterIsInstance<Element>()
+        .filter { it.tagName == tagName }
+
+private fun Element.ensureChildText(tagName: String, text: String) {
+    val element = childElement(tagName) ?: ownerDocument.createElement(tagName).also { appendChild(it) }
+    element.textContent = text
+}
+
+private fun Element.dependency(groupId: String, artifactId: String, importBom: Boolean = false): Element? =
+    childElements("dependency").firstOrNull { it.isDependency(groupId, artifactId, importBom) }
+
+private fun Element.isDependency(groupId: String, artifactId: String, importBom: Boolean = false): Boolean =
+    childText("groupId") == groupId &&
+        childText("artifactId") == artifactId &&
+        (!importBom || childText("type") == "pom" && childText("scope") == "import")
+
+private fun org.w3c.dom.Document.createDependency(
+    groupId: String,
+    artifactId: String,
+    version: String,
+    importBom: Boolean = false
+): Node {
+    val dependency = createElement("dependency")
+    dependency.appendTextElement("groupId", groupId)
+    dependency.appendTextElement("artifactId", artifactId)
+    dependency.appendTextElement("version", version)
+    if (importBom) {
+        dependency.appendTextElement("type", "pom")
+        dependency.appendTextElement("scope", "import")
+    }
+    return dependency
+}
+
+private fun Element.appendTextElement(tagName: String, text: String) {
+    appendChild(ownerDocument.createElement(tagName).also { it.textContent = text })
+}

--- a/buildSrc/src/test/kotlin/io/micronaut/platform/pom/OverrideableBomImportsTest.kt
+++ b/buildSrc/src/test/kotlin/io/micronaut/platform/pom/OverrideableBomImportsTest.kt
@@ -1,0 +1,72 @@
+package io.micronaut.platform.pom
+
+import java.nio.file.Files
+import kotlin.test.Test
+import org.gradle.testfixtures.ProjectBuilder
+
+class OverrideableBomImportsTest {
+
+    @Test
+    fun `checker accepts multiple allowlisted external bom imports`() {
+        val pomFile = Files.createTempFile("overrideable-bom-imports", ".xml").toFile()
+        pomFile.writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+              <properties>
+                <netty.version>4.2.12.Final</netty.version>
+                <example.version>1.2.3</example.version>
+              </properties>
+              <dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-bom</artifactId>
+                    <version>${'$'}{netty.version}</version>
+                    <type>pom</type>
+                    <scope>import</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.example</groupId>
+                    <artifactId>example-bom</artifactId>
+                    <version>${'$'}{example.version}</version>
+                    <type>pom</type>
+                    <scope>import</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-core-bom</artifactId>
+                    <version>${'$'}{micronaut.core.version}</version>
+                    <type>pom</type>
+                    <scope>import</scope>
+                  </dependency>
+                </dependencies>
+              </dependencyManagement>
+            </project>
+            """.trimIndent()
+        )
+
+        val project = ProjectBuilder.builder().build()
+        project.checkOverrideableBomImports(
+            pomFile,
+            listOf(
+                OverrideableBomImport(
+                    propertyName = "netty.version",
+                    importedBomGroupId = "io.netty",
+                    importedBomArtifactId = "netty-bom",
+                    owningBomGroupId = "io.micronaut",
+                    owningBomArtifactId = "micronaut-core-bom",
+                    owningBomVersionProperty = "micronaut.core.version"
+                ),
+                OverrideableBomImport(
+                    propertyName = "example.version",
+                    importedBomGroupId = "com.example",
+                    importedBomArtifactId = "example-bom",
+                    owningBomGroupId = "io.micronaut",
+                    owningBomArtifactId = "micronaut-core-bom",
+                    owningBomVersionProperty = "micronaut.core.version"
+                )
+            )
+        )
+    }
+}

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -1,3 +1,7 @@
+import io.micronaut.platform.pom.OverrideableBomImport
+import io.micronaut.platform.pom.checkOverrideableBomImports
+import io.micronaut.platform.pom.configureOverrideableBomImports
+
 plugins {
     id("io.micronaut.build.internal.bom")
 }
@@ -250,6 +254,24 @@ micronautBuild {
 }
 
 tasks {
+    val generatedMavenPom = layout.buildDirectory.file("publications/maven/pom-default.xml")
+    val overrideableBomImports = listOf(
+        OverrideableBomImport(
+            propertyName = "netty.version",
+            importedBomGroupId = "io.netty",
+            importedBomArtifactId = "netty-bom",
+            owningBomGroupId = "io.micronaut",
+            owningBomArtifactId = "micronaut-core-bom",
+            owningBomVersionProperty = "micronaut.core.version"
+        )
+    )
+
+    named("generatePomFileForMavenPublication") {
+        doLast {
+            configureOverrideableBomImports(generatedMavenPom.get().asFile, overrideableBomImports)
+        }
+    }
+
     // This is a workaround for the `jackson-databind` version being removed from the catalog
     // because it's not referenced anywhere anymore. However we must keep it for backwards
     // compatibility. This canbe removed after the next major release.
@@ -275,5 +297,20 @@ tasks {
             println(baseline.get().asFile)
             println(current.get().asFile)
         }
+    }
+
+    val checkOverrideableBomImports by registering {
+        description = "Verifies the published Maven platform POM exposes allowlisted overrideable BOM imports."
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOn("generatePomFileForMavenPublication")
+        inputs.file(generatedMavenPom)
+
+        doLast {
+            checkOverrideableBomImports(generatedMavenPom.get().asFile, overrideableBomImports)
+        }
+    }
+
+    check {
+        dependsOn(checkOverrideableBomImports)
     }
 }


### PR DESCRIPTION
This replaces the closed Netty-specific PR #2524 with the renewed DEV-581 scope: a generic, allowlisted Maven property override / external BOM import mechanism.

## Changes

- Adds `OverrideableBomImport` buildSrc support for allowlisted external BOM imports whose default property value is owned by an imported Micronaut BOM.
- Configures the first allowlist entry for `netty.version` so the generated platform POM imports `io.netty:netty-bom` with `${netty.version}` before `io.micronaut:micronaut-core-bom`.
- Replaces the Netty-only verification task with a generic `checkOverrideableBomImports` task wired into `:micronaut-platform:check`.
- Adds a buildSrc fixture proving the checker accepts multiple allowlisted entries without Netty-specific functions.

## Verification

- `./gradlew :buildSrc:test :micronaut-platform:generatePomFileForMavenPublication :micronaut-platform:checkOverrideableBomImports :micronaut-platform:check --quiet`
- `./gradlew :micronaut-platform:publishMavenPublicationToMavenLocal :micronaut-parent:publishParentPublicationToMavenLocal -Dmaven.repo.local=/tmp/dev155-m2 --quiet`
- Maven dependency-tree reproducer using the locally published `micronaut-parent` snapshot, `micronaut-http-server-netty`, `micronaut-http-client`, and child `<netty.version>4.2.11.Final</netty.version>`: all 70 `io.netty:*:jar` entries resolved to `4.2.11.Final`.
- Same reproducer without a child override: all 70 `io.netty:*:jar` entries resolved to the default from the configured `micronaut-core-bom`.

## Release Target

Base branch is `5.2.x` after the maintainer retargeted this PR from `5.0.x` on 2026-09-16, and the linked project is `5.2.0 Release`. Ambiguity preserved from intake: the original bug also reproduced on the 4.10.x stable line; any backport to an older line is a separate release-governance decision.

Fixes #2399

---
###### ✨ This message was AI-generated using claude-opus-5
