### PR TITLE
docs: document direct platform BOM usage

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -10,6 +10,48 @@ NOTE: Starting with Micronaut Platform 5.0, Kotlin applications built with Maven
 
 NOTE: The Micronaut Platform BOM has existed since Micronaut Framework 4, and corresponds to the Micronaut Framework 3 BOM which was published at `io.micronaut:micronaut-bom`. In Micronaut 4, we provide both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`).
 
+== Using the Micronaut Platform BOM
+
+If your build does not use the Micronaut Gradle Plugin or the Micronaut Maven Plugin, import the Micronaut Platform BOM directly to manage Micronaut dependency versions.
+
+For Gradle builds, add the platform dependency and then declare Micronaut dependencies without versions:
+
+[source,kotlin]
+----
+val micronautVersion: String by project // from gradle.properties
+
+dependencies {
+    implementation(platform("io.micronaut.platform:micronaut-platform:$micronautVersion"))
+    implementation("io.micronaut.data:micronaut-data-jdbc")
+}
+----
+
+For Maven builds, import the platform BOM in `dependencyManagement` and then declare Micronaut dependencies without versions:
+
+[source,xml]
+----
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut.platform</groupId>
+      <artifactId>micronaut-platform</artifactId>
+      <version>${micronaut.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>io.micronaut.data</groupId>
+    <artifactId>micronaut-data-jdbc</artifactId>
+  </dependency>
+</dependencies>
+----
+
+The BOM manages dependency versions. It does not provide Gradle dependency aliases; use the Gradle version catalog when you want catalog aliases such as `mn.micronaut.data.jdbc`.
+
 == The Micronaut Platform catalog
 
 For Gradle users, the platform is also published as a https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog[version catalog] which can be used in your build scripts to add "blessed" dependencies to your project.


### PR DESCRIPTION
## Summary

- Add direct Micronaut Platform BOM import guidance for non-plugin Gradle and Maven users.
- Clarify that the BOM manages dependency versions while the Gradle version catalog provides aliases.

## Validation

- `git fetch origin 5.0.x` and `git rebase origin/5.0.x` completed without conflicts before opening this PR.
- `./gradlew :micronaut-platform:publishToMavenLocal` passed for `5.0.1-SNAPSHOT`.
- Throwaway Gradle project using `implementation(platform("io.micronaut.platform:micronaut-platform:$micronautVersion"))` resolved versionless `io.micronaut.data:micronaut-data-jdbc` to `5.0.1`.
- Parsed the locally published Platform POM and confirmed it is `packaging=pom`, imports `micronaut-data-bom`, and manages `micronaut-data-jdbc` through `micronaut.data.version=5.0.1`.
- `./gradlew publishGuide docs` passed and the new section rendered in `build/working/02-docs-raw/all/guide/index.html`.

Paperclip: DEV-1020

---
###### ✨ This message was AI-generated using gpt-5.5
