### PR TITLE
docs: clarify Micronaut Platform BOM usage

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -4,9 +4,47 @@ The Micronaut Platform is a collection of modules that can be used to build Micr
 
 It aggregates many of the individual Micronaut module BOMs and provides a single BOM to manage the versions of all the modules.
 
-If you use either the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Micronaut Gradle Plugin] or the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Micronaut Maven Plugin], you do not need to add this module to your project as it will be added automatically.
+If you use either the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Micronaut Gradle Plugin] or the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Micronaut Maven Plugin], you do not need to add this module to your project because it will be added automatically.
 
-NOTE: The Micronaut Platform BOM exists since Micronaut Framework 4, and corresponds to the Micronaut Framework  3 BOM which was published at `io.micronaut:micronaut-bom`. In Micronaut 4, we provide both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`).
+NOTE: The Micronaut Platform BOM is available starting with Micronaut Framework 4, and replaces the Micronaut Framework 3 BOM published at `io.micronaut:micronaut-bom`. In Micronaut 4, both the Micronaut Platform BOM (`io.micronaut.platform:micronaut-platform`) and the Micronaut Core BOM (`io.micronaut:micronaut-core-bom`) are available.
+
+== Using the Micronaut Platform BOM directly
+
+If you are not using the Micronaut Gradle or Maven plugin, import the Micronaut Platform BOM in your build and omit versions for dependencies managed by the platform.
+
+For Gradle, add the platform as a dependency constraint:
+
+[source,kotlin]
+----
+dependencies {
+    implementation(platform("io.micronaut.platform:micronaut-platform:$micronautVersion"))
+    implementation("io.micronaut.data:micronaut-data-jdbc")
+}
+----
+
+For Maven, import the BOM in `dependencyManagement`:
+
+[source,xml]
+----
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut.platform</groupId>
+      <artifactId>micronaut-platform</artifactId>
+      <version>${micronautVersion}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>io.micronaut.data</groupId>
+    <artifactId>micronaut-data-jdbc</artifactId>
+  </dependency>
+</dependencies>
+----
 
 == The Micronaut Platform catalog
 


### PR DESCRIPTION
## Summary
- Add direct Gradle and Maven examples for importing the Micronaut Platform BOM when users are not using the Micronaut build plugins.
- Clarify the Micronaut Framework 4 BOM note and remove a small wording issue in the introduction.

## Validation
- `./gradlew publishGuide --no-daemon` using Temurin JDK 17: passed.
- `./gradlew docs --no-daemon` using Temurin JDK 17: passed.
- `./gradlew publishToMavenLocal --no-daemon` using Temurin JDK 17: passed; published the snapshot BOM and version catalog locally for fact-checking.
- Throwaway Gradle project imported `io.micronaut.platform:micronaut-platform:4.2.0-SNAPSHOT` as a platform and resolved `io.micronaut.data:micronaut-data-jdbc` without specifying a version.
- Throwaway Maven project imported the same BOM in `dependencyManagement` and resolved `io.micronaut.data:micronaut-data-jdbc` without specifying a version.
- Checked user-facing links in the generated guide: Micronaut Gradle Plugin, Micronaut Maven Plugin, Gradle version catalog docs, repository, and releases all returned HTTP 200.

Paperclip: DEV-1305

---
###### ✨ This message was AI-generated using gpt-5.5
