### PR TITLE
docs: clarify Gradle Platform BOM usage

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -12,7 +12,7 @@ NOTE: The Micronaut Platform BOM is available starting with Micronaut Framework 
 
 If you are not using the Micronaut Gradle or Maven plugin, import the Micronaut Platform BOM in your build and omit versions for dependencies managed by the platform.
 
-For Gradle, add the platform as a dependency constraint:
+For Gradle, add the platform as a platform dependency:
 
 [source,kotlin]
 ----


### PR DESCRIPTION
## Summary
- Clarifies the Micronaut Platform guide's Gradle BOM wording so `implementation(platform(...))` is described as a platform dependency rather than as a dependency constraint.

## Validation
- `./gradlew publishGuide`
- `./gradlew docs`
- Throwaway Gradle project resolved `io.micronaut.data:micronaut-data-jdbc` through `io.micronaut.platform:micronaut-platform:4.10.16` and the published version catalog alias `mn.micronaut.data.jdbc`.
- Throwaway Maven project resolved `io.micronaut.data:micronaut-data-jdbc` through the imported `io.micronaut.platform:micronaut-platform:4.10.16` BOM.
- Checked guide links for repository, releases, Gradle plugin docs, Maven plugin docs, and Gradle version catalog docs; all returned HTTP 200.

Fixes DEV-1374

---
###### ✨ This message was AI-generated using gpt-5.5
