### PR TITLE
add Maven shared utils to native Maven plugin classpath

### DIFF
--- a/parent/src/pom-template.xml
+++ b/parent/src/pom-template.xml
@@ -258,6 +258,14 @@
                     <artifactId>native-maven-plugin</artifactId>
                     <version>${maven.native.plugin.version}</version>
                     <extensions>true</extensions>
+                    <dependencies>
+                        <!-- Required by the CycloneDX plugin bundled with native-maven-plugin. -->
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-shared-utils</artifactId>
+                            <version>3.4.2</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <imageName>${project.artifactId}</imageName>
                         <mainClass>${exec.mainClass}</mainClass>


### PR DESCRIPTION
The GraalVM native Maven plugin bundles CycloneDX as a runtime dependency. When native builds run, CycloneDX requires org.apache.maven.shared.utils.logging.MessageUtils, but maven-shared-utils is not present in the plugin’s isolated classpath.

This causes native Maven builds to fail during write-args-file before native-image is invoked:

A required class was missing: org/apache/maven/shared/utils/logging/MessageUtils

Add maven-shared-utils explicitly to the inherited native-maven-plugin configuration so all Micronaut Maven native projects receive the required class at build time.
